### PR TITLE
Encode binary responses using base 64

### DIFF
--- a/src/main/php/com/amazon/aws/lambda/ResponseDocument.class.php
+++ b/src/main/php/com/amazon/aws/lambda/ResponseDocument.class.php
@@ -5,13 +5,33 @@ use web\io\Output;
 /**
  * Response document
  *
- * @test com.amazon.aws.lambda.unittest.ResponseDocumentTest
+ * @test  com.amazon.aws.lambda.unittest.ResponseDocumentTest
  */
 class ResponseDocument extends Output {
   public $document;
 
   /** @return web.io.Output */
   public function stream() { return $this; }
+
+  /**
+   * Returns whether a mimetype can safely be regarded as purely textual:
+   * Any mimetype beginning with "text/" as well as JSON and XML types,
+   * including (potentially versioned) vendor mimetypes.
+   *
+   * @param  string $mime May include parameters such as `charset=utf-8`
+   * @return bool
+   */
+  private function isText($mime) {
+    return (
+      0 === strncmp($mime, 'text/', 5) ||
+      0 === strncmp($mime, 'application/xml', 15) ||
+      0 === strncmp($mime, 'application/json', 16) ||
+      (0 === strncmp($mime, 'application/', 12) && ($p= strcspn($mime, ';')) && (
+        0 === substr_compare($mime, '+json', $p - 5, 5) ||
+        0 === substr_compare($mime, '+xml', $p - 4, 4)
+      ))
+    );
+  }
 
   /**
    * Begins a request
@@ -24,10 +44,16 @@ class ResponseDocument extends Output {
     $this->document= [
       'statusCode'        => $status,
       'statusDescription' => $message,
-      'isBase64Encoded'   => false,
+      'isBase64Encoded'   => true,
       'headers'           => [],
       'body'              => null,
     ];
+
+    // If no content type is given or it's definitely text, pass through
+    // content without encoding to base64 to be more efficient.
+    if (!isset($headers['Content-Type']) || $this->isText($headers['Content-Type'][0])) {
+      $this->document['isBase64Encoded']= false;
+    }
 
     foreach ($headers as $name => $values) {
       if ('Set-Cookie' === $name) {
@@ -61,14 +87,18 @@ class ResponseDocument extends Output {
    * @param  string $bytes
    * @return void
    */
-  public function write($bytes) { 
+  public function write($bytes) {
     $this->document['body'].= $bytes;
   }
 
   /** @return void */
   public function finish() {
-    if (null !== $this->document['body']) {
-      $this->document['headers']['Content-Length']= (string)strlen($this->document['body']);
+    if (null === $this->document['body']) return;
+
+    // Report unencoded length in headers
+    $this->document['headers']['Content-Length']= (string)strlen($this->document['body']);
+    if ($this->document['isBase64Encoded']) {
+      $this->document['body']= base64_encode($this->document['body']);
     }
   }
 }

--- a/src/test/php/com/amazon/aws/lambda/unittest/ResponseDocumentTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/ResponseDocumentTest.class.php
@@ -48,6 +48,63 @@ class ResponseDocumentTest {
     );
   }
 
+  #[Test, Values(['text/plain', 'text/html', 'text/plain; charset=utf-8'])]
+  public function with_text_content($mime) {
+    $out= new ResponseDocument();
+    $out->begin(200, 'OK', ['Content-Type' => [$mime]]);
+    $out->write('Test');
+    $out->close();
+
+    Assert::equals(
+      [
+        'statusCode'        => 200,
+        'statusDescription' => 'OK',
+        'isBase64Encoded'   => false,
+        'headers'           => ['Content-Type' => $mime, 'Content-Length' => '4'],
+        'body'              => 'Test',
+      ],
+      $out->document
+    );
+  }
+
+  #[Test, Values(['application/json', 'application/json; charset=utf-8', 'application/vnd.example.test-v2+json', 'application/vnd.example.test-v2+json; charset=utf-8'])]
+  public function with_json_content($mime) {
+    $out= new ResponseDocument();
+    $out->begin(200, 'OK', ['Content-Type' => [$mime]]);
+    $out->write('{"key":"value"}');
+    $out->close();
+
+    Assert::equals(
+      [
+        'statusCode'        => 200,
+        'statusDescription' => 'OK',
+        'isBase64Encoded'   => false,
+        'headers'           => ['Content-Type' => $mime, 'Content-Length' => '15'],
+        'body'              => '{"key":"value"}',
+      ],
+      $out->document
+    );
+  }
+
+  #[Test]
+  public function with_binary_content() {
+    $out= new ResponseDocument();
+    $out->begin(200, 'OK', ['Content-Type' => ['image/gif']]);
+    $out->write('GIF89a...');
+    $out->close();
+
+    Assert::equals(
+      [
+        'statusCode'        => 200,
+        'statusDescription' => 'OK',
+        'isBase64Encoded'   => true,
+        'headers'           => ['Content-Type' => 'image/gif', 'Content-Length' => '9'],
+        'body'              => 'R0lGODlhLi4u',
+      ],
+      $out->document
+    );
+  }
+
   #[Test]
   public function write_to_stream() {
     $out= new ResponseDocument();


### PR DESCRIPTION
> To handle binary payloads for AWS Lambda proxy integrations, you must base64-encode your function`s response

*Quoting the AWS docs*