### PR TITLE
Fix redirects yielding "null"

### DIFF
--- a/src/main/php/com/amazon/aws/lambda/HttpApi.class.php
+++ b/src/main/php/com/amazon/aws/lambda/HttpApi.class.php
@@ -52,6 +52,8 @@ abstract class HttpApi extends Handler {
       try {
         foreach ($routing->service($req->pass('context', $context)->pass('request', $in->context()), $res) ?? [] as $_) { }
         $logging->log($req, $res);
+        $res->end();
+
         return $res->output()->document;
       } catch (Throwable $t) {
         $e= $t instanceof Error ? $t : new InternalServerError($t);

--- a/src/test/php/com/amazon/aws/lambda/unittest/HttpApiTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/HttpApiTest.class.php
@@ -111,6 +111,29 @@ class HttpApiTest {
   }
 
   #[Test]
+  public function sending_redirect() {
+    $fixture= new class($this->environment) extends HttpApi {
+      public function routes($env) {
+        return ['/' => function($req, $res) {
+          $res->answer(302);
+          $res->header('Location', 'https://example.com');
+        }];
+      }
+    };
+
+    Assert::equals(
+      [
+        'statusCode'        => 302,
+        'statusDescription' => 'Found',
+        'isBase64Encoded'   => false,
+        'headers'           => ['Location' => 'https://example.com', 'Content-Length' => 0],
+        'body'              => null,
+      ],
+      $this->invoke($fixture->target(), 'GET')
+    );
+  }
+
+  #[Test]
   public function throwing_error() {
     $fixture= new class($this->environment) extends HttpApi {
       public function routes($env) {


### PR DESCRIPTION
Instead of actually performing the redirect, the HTTP API Gateway simply yielded a plain text response showing the word `null`. Problem is that the response might not have been flushed correctly, fix is to call `Response::end()`.