### PR TITLE
Adapt to changes in web API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ AWS Lambda Webservices change log
 
 ## ?.?.? / ????-??-??
 
+* **Heads up:** Dropped support for PHP < 7.4, see xp-framework/rfc#343
+  (@thekid)
+
 ## 2.3.0 / 2024-05-20
 
 * Added support for dispatching on application level, introduced in

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
     "xp-forge/lambda": "^5.0",
-    "xp-forge/web": "^4.0 | ^3.0",
-    "php": ">=7.0.0"
+    "xp-forge/web": "dev-feature/websockets as 5.0.0",
+    "php": ">=7.4.0"
   },
   "require-dev" : {
     "xp-framework/test": "^2.0 | ^1.0"

--- a/src/main/php/com/amazon/aws/lambda/FromApiGateway.class.php
+++ b/src/main/php/com/amazon/aws/lambda/FromApiGateway.class.php
@@ -54,7 +54,7 @@ class FromApiGateway implements Input {
   public function method() { return $this->event['requestContext']['http']['method'] ?? 'GET'; }
 
   /** @return string */
-  public function uri() {
+  public function resource() {
     return $this->event['rawQueryString']
       ? $this->event['rawPath'].'?'.$this->event['rawQueryString']
       : $this->event['rawPath']

--- a/src/main/php/com/amazon/aws/lambda/Tracing.class.php
+++ b/src/main/php/com/amazon/aws/lambda/Tracing.class.php
@@ -1,20 +1,22 @@
 <?php namespace com\amazon\aws\lambda;
 
+use util\Objects;
 use web\Logging;
 use web\logging\ToFunction;
 
 class Tracing extends Logging {
 
   public function __construct(Environment $environment) {
-    parent::__construct(new ToFunction(function($request, $response, $error= null) use($environment) {
-      $query= $request->uri()->query();
+    parent::__construct(new ToFunction(function($status, $method, $resource, $hints) use($environment) {
+      $traceId= $hints['traceId'];
+      unset($hints['traceId']);
       $environment->trace(sprintf(
         'TRACE [%s] %d %s %s %s',
-        $request->value('context')->traceId,
-        $response->status(),
-        $request->method(),
-        $request->uri()->path().($query ? '?'.$query : ''),
-        $error ? $error->toString() : ''
+        $traceId,
+        $status,
+        $method,
+        $resource,
+        Objects::stringOf($hints)
       ));
     }));
   }

--- a/src/test/php/com/amazon/aws/lambda/unittest/FromApiGatewayTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/FromApiGatewayTest.class.php
@@ -79,13 +79,13 @@ class FromApiGatewayTest {
   }
 
   #[Test]
-  public function uri() {
-    Assert::equals('/default/test', $this->fixture('GET')->uri());
+  public function resource() {
+    Assert::equals('/default/test', $this->fixture('GET')->resource());
   }
 
   #[Test]
-  public function uri_including_query() {
-    Assert::equals('/default/test?name=Test', $this->fixture('GET', 'name=Test')->uri());
+  public function resource_including_query() {
+    Assert::equals('/default/test?name=Test', $this->fixture('GET', 'name=Test')->resource());
   }
 
   #[Test, Values([[[]], [['accept' => '*/*', 'user-agent' => 'test']]])]

--- a/src/test/php/com/amazon/aws/lambda/unittest/InvocationTest.class.php
+++ b/src/test/php/com/amazon/aws/lambda/unittest/InvocationTest.class.php
@@ -297,7 +297,7 @@ abstract class InvocationTest {
     $this->invoke($fixture, 'GET', 'name=Test');
 
     Assert::equals(
-      "TRACE [Root=1-dc99d00f-c079a84d433534434534ef0d;Parent=91ed514f1e5c03b2;Sampled=1] 200 GET /default/test?name=Test \n",
+      "TRACE [Root=1-dc99d00f-c079a84d433534434534ef0d;Parent=91ed514f1e5c03b2;Sampled=1] 200 GET /default/test?name=Test []\n",
       $this->trace->bytes()
     );
   }


### PR DESCRIPTION
This pull request makes the library compatible with the upcoming [xp-forge/web](https://github.com/xp-forge/web) version 5.0, see xp-forge/web#121:

* [x] Input::uri() -> Input::resource() renaming
* [x] Logging API refactoring
* [x] Dropped support for PHP < 7.4, see xp-framework/rfc#343
* [ ] WebSockets support. TODO: Check whether this can be done via a single AWS lamba function at all, otherwise yield errors
